### PR TITLE
fix: deprecated and confuse UI

### DIFF
--- a/View/Backup.html.twig
+++ b/View/Backup.html.twig
@@ -85,10 +85,10 @@
 												</tr>
 											{% else %}
 												{% for day, entries in fsc.backup_list %}
-													<tr class="table-dark">
-														<th colspan="5" class="py-2">
+													<tr class="table-primary">
+														<th colspan="5" class="py-2 text-primary-emphasis">
 															<i class="fa-solid fa-calendar-day me-2"></i>
-															{{ day[6:2] }}/{{ day[4:2] }}/{{ day[0:4] }}
+															{{ day[8:2] }}/{{ day[5:2] }}/{{ day[0:4] }}
 														</th>
 													</tr>
 													<tr class="table-secondary">


### PR DESCRIPTION
La UI de antes estaba pensada para un formato de fecha diferente, además el color que tiene actual el indicador de la fecha de los archivos está mal, todo esto a raiz de esta issue: https://facturascripts.com/issues/113-813-112

Por lo tanto, se ha modificado la vista de 'Historial' para que en vez de ser un fondo negro sea azul claro y además se ha arreglado el muestreo de la fecha (antes era YYYYMMDD  y ahora YYYY-MM-DD)