### PR TITLE
Actualiza formato de fecha en Backup.html.twig

### DIFF
--- a/View/Backup.html.twig
+++ b/View/Backup.html.twig
@@ -88,7 +88,7 @@
 													<tr class="table-primary">
 														<th colspan="5" class="py-2 text-primary-emphasis">
 															<i class="fa-solid fa-calendar-day me-2"></i>
-															{{ day[8:2] }}/{{ day[5:2] }}/{{ day[0:4] }}
+															{% set _dp = day | split('-') %}{{ _dp[2] }}/{{ _dp[1] }}/{{ _dp[0] }}
 														</th>
 													</tr>
 													<tr class="table-secondary">


### PR DESCRIPTION
https://facturascripts.com/roadmap/4700
No he podido reproducir el error, pero he modificado la forma de formatear la fecha de los archivos por una mas robusta evitando asi el fallo de la tarea. 
Se modifica la forma en que se muestra la fecha en el archivo Backup.html.twig, cambiando el método de extracción de la fecha para utilizar la función split, mejorando así la legibilidad y el formato de la misma.